### PR TITLE
only query global scope addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Examples:
           $ racknet public
           104.130.0.127
 
-          $ racknet service ipv6
-          fe80::be76:4eff:fe20:b452
+          $ racknet public ipv6
+          2001:4802:1234:5678:90ab:cdef:0123:4567
 
 Examples when run with Docker:
           $ docker run --net=host racknet/ip public

--- a/racknet
+++ b/racknet
@@ -44,7 +44,7 @@ obtainIP() {
   esac
 
   INTERFACE=${2:-"eth0"}
-  addrOut=$(ip -f ${IP_VERSION} addr show ${INTERFACE} 2> /dev/null )
+  addrOut=$(ip -f ${IP_VERSION} addr show ${INTERFACE} scope global 2> /dev/null )
   if [ "$?" != 0 ]; then
     echo "Unable to find an $INTERFACE interface on $IPV"
     echo ""


### PR DESCRIPTION
All the addresses we're interested in have 'global' scope according to
'ip' ('global' does not necessarily mean 'globally routable', as 10.x
ipv4 addresses having such a scope show).  previously, a link-local
address would show up for 'racknet/ip ... ipv6' for both 'public' and
'private' values of '...'.  After this change only valid addresses show
up.
